### PR TITLE
v2.0.1 - Adding compatibility redirect to previous release

### DIFF
--- a/src/routes/check/+page.server.ts
+++ b/src/routes/check/+page.server.ts
@@ -3,7 +3,6 @@ import type { Software } from "$lib/software.js";
 import { error } from "@sveltejs/kit";
 import { getDefederations } from "$lib/defederated";
 
-
 export async function load({ url }) {
     const nameParam = url.searchParams.get('name');
     const softwareParam = url.searchParams.get('software') ?? '';

--- a/src/routes/check/[name]/+page.server.ts
+++ b/src/routes/check/[name]/+page.server.ts
@@ -1,0 +1,6 @@
+import { redirect } from '@sveltejs/kit';
+
+//Redirect links in the old URL format to the new one
+export async function load({ params }) {
+    redirect(301, `/check?name=${params.name}&software=lemmy`);
+}


### PR DESCRIPTION
While updating to v2.0.0 a breaking change in the URL format happens. This PR introduces a redirect to fix that.